### PR TITLE
Fix rect origin when drawing dotImage

### DIFF
--- a/FXPageControl/FXPageControl.m
+++ b/FXPageControl/FXPageControl.m
@@ -167,7 +167,7 @@ const CGPathRef FXPageControlDotShapeTriangle = (const CGPathRef)3;
             }
 			if (dotImage)
 			{
-				[dotImage drawInRect:CGRectMake((self.dotSize - dotImage.size.width) / 2, (self.frame.size.height - dotImage.size.height) / 2, dotImage.size.width, dotImage.size.height)];
+				[dotImage drawInRect:CGRectMake(-dotImage.size.width / 2, -dotImage.size.height / 2, dotImage.size.width, dotImage.size.height)];
 			}
 			else
 			{


### PR DESCRIPTION
CGContextTranslateCTM call shifts the drawing origin to the centre of the dot, so the image ended up being placed 1/2 size below of where it should be.
