### PR TITLE
Added support for VoiceOver

### DIFF
--- a/FXPageControl/FXPageControl.m
+++ b/FXPageControl/FXPageControl.m
@@ -430,4 +430,20 @@ const CGPathRef FXPageControlDotShapeTriangle = (const CGPathRef)3;
     return [self sizeThatFits:self.bounds.size];
 }
 
+#pragma mark - Accessibility
+
+- (UIAccessibilityTraits)accessibilityTraits {
+    return UIAccessibilityTraitAdjustable;
+}
+
+- (void)accessibilityIncrement {
+    self.currentPage = self.currentPage + 1;
+    [self sendActionsForControlEvents:UIControlEventValueChanged];
+}
+
+- (void)accessibilityDecrement {
+    self.currentPage = self.currentPage - 1;
+    [self sendActionsForControlEvents:UIControlEventValueChanged];
+}
+
 @end


### PR DESCRIPTION
When VoiceOver is enabled UIPageControls are ‘adjustable’ elements.
When they have focus, a swipe up increments the value and a swipe down
decrements it.

Adding these methods makes FXPageControl’s behaviour consistent with
UIPageControl when VoiceOver is enabled.
