### PR TITLE
Add optional sizeForDotAtIndex protocol method

### DIFF
--- a/FXPageControl/FXPageControl.m
+++ b/FXPageControl/FXPageControl.m
@@ -155,12 +155,18 @@ const CGPathRef FXPageControlDotShapeTriangle = (const CGPathRef)3;
                 {
                     dotColor = _selectedDotColor ?: [UIColor blackColor];
                 }
+                if ([_delegate respondsToSelector:@selector(pageControl:sizeForDotAtIndex:)])
+                {
+                    dotSize = [_delegate pageControl:self sizeForDotAtIndex:i];
+                }
+                else {
+                    dotSize = _selectedDotSize ?: _dotSize;
+                }
                 dotShadowBlur = _selectedDotShadowBlur;
                 dotShadowColor = _selectedDotShadowColor;
                 dotShadowOffset = _selectedDotShadowOffset;
                 dotBorderWidth = _selectedDotBorderWidth;
                 dotBorderColor = _selectedDotBorderColor;
-                dotSize = _selectedDotSize ?: _dotSize;
             }
             else
             {
@@ -201,12 +207,18 @@ const CGPathRef FXPageControlDotShapeTriangle = (const CGPathRef)3;
                     }
                     dotColor = [dotColor colorWithAlphaComponent:0.25];
                 }
+                if ([_delegate respondsToSelector:@selector(pageControl:sizeForDotAtIndex:)])
+                {
+                    dotSize = [_delegate pageControl:self sizeForDotAtIndex:i];
+                }
+                else {
+                    dotSize = _dotSize;
+                }
                 dotShadowBlur = _dotShadowBlur;
                 dotShadowColor = _dotShadowColor;
                 dotShadowOffset = _dotShadowOffset;
                 dotBorderWidth = _dotBorderWidth;
                 dotBorderColor = _dotBorderColor;
-                dotSize = _dotSize;
             }
 
             [dotColor setFill];

--- a/FXPageControl/include/FXPageControl.h
+++ b/FXPageControl/include/FXPageControl.h
@@ -97,6 +97,7 @@ IB_DESIGNABLE @interface FXPageControl : UIControl
 - (nullable UIImage *)pageControl:(FXPageControl *)pageControl selectedImageForDotAtIndex:(NSInteger)index;
 - (CGPathRef)pageControl:(FXPageControl *)pageControl selectedShapeForDotAtIndex:(NSInteger)index;
 - (UIColor *)pageControl:(FXPageControl *)pageControl selectedColorForDotAtIndex:(NSInteger)index;
+- (CGFloat)pageControl:(FXPageControl *)pageControl sizeForDotAtIndex:(NSInteger)index;
 
 @end
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ Note that CGPathRefs that are created and returned from the `-pageControl:shapeF
 
 Release Notes
 --------------
+Version 1.7
+
+- Added optional `sizeForDotAtIndex` protocol method
 
 Version 1.6
 


### PR DESCRIPTION
Added an optional `sizeForDotAtIndex` protocol method to provide individual sizes for dots if needed. I wanted to customise each dot size based on its position relative to the the current page dot to match the Disney app's carousel page control where adjacent dots are smaller than the selected dot but larger than the other dots.
<img width="95" alt="Screenshot 2023-10-05 at 9 25 35 AM" src="https://github.com/nicklockwood/FXPageControl/assets/103429618/bc8cfefe-0e68-4def-966e-9f333a08b5b8">